### PR TITLE
[FEATURE][TAS-135] Remove Google Analytics (not GDPR Compliant)

### DIFF
--- a/desparchado/templates/layout/base.html
+++ b/desparchado/templates/layout/base.html
@@ -77,16 +77,6 @@
     {# Extra JS #}
     {% block javascript %}{% endblock javascript %}
 
-    {# Global site tag (gtag.js) - Google Analytics #}
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-3N7JDK8B9C"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-3N7JDK8B9C');
-    </script>
-
     {# Umami Open Source Analytics #}
     <script defer src="https://cloud.umami.is/script.js" data-website-id="1ccee07e-d5e4-4c95-a986-3b1569f29d9b"></script>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Google Analytics tracking from the site’s base layout; Umami analytics remains active.
  * Eliminates loading of the GA script, reducing third‑party requests and potential tracking cookies from GA.
  * No changes to page layout, navigation, or core functionality.
  * Users should experience the same interface, with potential minor improvements in page load performance due to fewer external scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->