### PR TITLE
[FIX] Arrow in select group was keeping select to work properly

### DIFF
--- a/desparchado/frontend/styles/forms/inputs/select-group.scss
+++ b/desparchado/frontend/styles/forms/inputs/select-group.scss
@@ -49,6 +49,7 @@
       align-items: center;
       justify-content: center;
       font-family: cursive;
+      pointer-events: none;
 
       @media (min-width: map.get($breakpoints, m)) {
         padding: 0.75rem 1.5rem;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the decorative chevron in grouped select inputs intercepted clicks. Interactions now pass through to the select control as expected, improving usability on both desktop and touch devices.
  * No visual changes; keyboard navigation and behavior remain the same, with improved click/tap reliability and consistency across browsers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->