### PR TITLE
[FEATURE][NA] Fix search and date filters to stack instead of being mutually exclusive

### DIFF
--- a/_bmad-output/implementation-artifacts/spec-special-detail-unified-filters.md
+++ b/_bmad-output/implementation-artifacts/spec-special-detail-unified-filters.md
@@ -41,7 +41,8 @@ context: []
 | Multiple dates selected | `?fecha=2026-04-08&fecha=2026-04-09` | Union of events from both dates; both chips show checked | N/A |
 | All chips unchecked, no other filter | No `fecha`, no `q`, no `target_audience` | All published events shown; no chip checked | N/A |
 | All chips unchecked + audience filter | No `fecha`, `target_audience=familia` | No date filter; audience filter applied to all events | N/A |
-| Search overrides date | `?q=taller` | Full-text search used; date chips unaffected (unchecked) | Query < 3 chars: ignored |
+| Search + date combined | `?q=taller&fecha=2026-04-08` | Full-text search applied first, then date filter narrows results | Query < 3 chars: ignored |
+| Search only | `?q=taller` | Full-text search across all dates; no date filter applied | Query < 3 chars: ignored |
 | Invalid `fecha` value | `?fecha=not-a-date` | Invalid value silently dropped; remaining valid dates used | N/A |
 
 </frozen-after-approval>
@@ -66,12 +67,14 @@ context: []
 - Given two date chips are checked and the form is submitted, when the page reloads, events from both dates appear in the list together.
 - Given a checked chip is unchecked and "Buscar" is clicked, when the page reloads, events for only the remaining checked dates are shown.
 - Given all chips are unchecked and audience filter is active, when "Buscar" is clicked, no date filter is applied (all audience-matched events shown).
+- Given a search term and a date chip are both active, when the form is submitted, only events matching the search term on that date are shown.
 - Given `ANALYTICS_ENABLED=True`, when the submit button is clicked, Umami fires `special-event-search`.
 - Given `ANALYTICS_ENABLED=True`, when a date chip label is clicked, Umami fires `special-date-filter`.
 - Given an event card is rendered, when clicked, Umami fires `special-event-card`.
 
 ## Spec Change Log
 
+- **2026-04-08 — bug fix:** Search and date filters were mutually exclusive (`elif`). Fixed to stack independently (`if`/`if`). Updated I/O matrix (replaced "Search overrides date" with combined and search-only rows) and added AC for combined case. KEEP: all other filter behavior.
 - **2026-04-08 — human renegotiation:** Removed auto-select behavior. Original spec auto-selected today/earliest date when no `fecha` param was present. User explicitly requested no default date on page load. Updated: Always boundary, I/O matrix rows "No params" and "All chips unchecked", task description, and AC. KEEP: all other behavior (multi-date union, invalid fecha dropped, chip-as-checkbox pattern, Umami tracking).
 
 ## Design Notes

--- a/desparchado/frontend/styles/sections/_event-details.scss
+++ b/desparchado/frontend/styles/sections/_event-details.scss
@@ -230,7 +230,7 @@ $mobile-actions-overlap: -3.75rem;
     padding: 4rem 1rem 5rem;
 
     @media (min-width: map.get($breakpoints, m)) {
-      padding: 0 0 10rem;
+      padding: 0 0 5rem;
     }
   }
 

--- a/specials/tests/test_views.py
+++ b/specials/tests/test_views.py
@@ -146,6 +146,26 @@ def test_invalid_fecha_value_is_ignored(django_app):
 
 
 @pytest.mark.django_db
+def test_search_and_date_filter_stack(django_app):
+    target_date = now() + timedelta(days=3)
+    other_date = now() + timedelta(days=7)
+
+    match = EventFactory(title="Taller de pintura", event_date=target_date)
+    wrong_date = EventFactory(title="Taller de pintura", event_date=other_date)
+    wrong_title = EventFactory(title="Concierto de jazz", event_date=target_date)
+    special = SpecialFactory(related_events=[match, wrong_date, wrong_title])
+
+    response = django_app.get(
+        reverse('specials:special_detail', args=[special.slug]),
+        {'q': 'taller', 'fecha': str(localtime(target_date).date())},
+        status=200,
+    )
+    assert match in response.context['events']
+    assert wrong_date not in response.context['events']
+    assert wrong_title not in response.context['events']
+
+
+@pytest.mark.django_db
 def test_no_fecha_shows_all_events(django_app):
     event_a = EventFactory(event_date=now() + timedelta(days=1))
     event_b = EventFactory(event_date=now() + timedelta(days=10))

--- a/specials/views.py
+++ b/specials/views.py
@@ -63,7 +63,7 @@ class SpecialDetailView(DetailView):
         if target_audience_filter_value not in Event.TargetAudience:
             target_audience_filter_value = ''
 
-        # Apply search or date filter
+        # Apply filters independently — all three can stack
         has_search = (
             search_query_value
             and len(search_query_value) >= self.search_query_min_length
@@ -74,7 +74,7 @@ class SpecialDetailView(DetailView):
                 search_str=search_query_value,
                 search_str_min_length=self.search_query_min_length,
             )
-        elif selected_dates:
+        if selected_dates:
             events_queryset = events_queryset.filter(
                 event_date__date__in=selected_dates,
             )

--- a/specials/views.py
+++ b/specials/views.py
@@ -17,16 +17,12 @@ class SpecialDetailView(DetailView):
     """
     Displays details of a `Special` instance and its related published events.
 
-    The view supports:
-    - Filtering events by a selected.
-    - Searching events by keyword.
-    - Pagination of event results.
+    All filters stack cumulatively:
+    - `q`: full-text search via `search_events` when >= `search_query_min_length` chars.
+    - `fecha`: one or more dates; events are filtered to the union of those dates.
+    - `target_audience`: narrows results to the given audience value.
 
-    Behavior:
-    - If a search query (`q`) is provided and its length >= `search_query_min_length`,
-      events are filtered using the `search_events` service.
-    - Otherwise, events are filtered by date (`fecha`). If no date is given, it defaults
-      to today’s date (if available) or the earliest available event date.
+    When no filters are active, all published events for the special are returned.
     """
     model = Special
     search_query_name = "q"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where search and date filters on the special events detail page could not be used together; both filters now properly work in conjunction to refine results.

* **Style**
  * Fine-tuned bottom padding on event detail content sections for improved visual spacing on tablet and mobile devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->