### PR TITLE
[FEATURE][NA] Always show featured event card images on touch screens

### DIFF
--- a/desparchado/frontend/components/presentational/components/featured-event-card/styles.scss
+++ b/desparchado/frontend/components/presentational/components/featured-event-card/styles.scss
@@ -79,6 +79,10 @@
     transition-property: clip-path;
     transition-timing-function: $ease-out-quart;
     will-change: clip-path;
+
+    @media (hover: none) {
+      clip-path: circle(150% at 20% 100%);
+    }
   }
 
   &__wrapper {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Optimized featured event card appearance on touch devices and devices without hover support for improved visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->