### PR TITLE
[FEATURE][TAS-152] Add place filter, past-chip class, and active filter summary to special detail page #676

### DIFF
--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -18,6 +18,18 @@
 **Finding:** `500.html` uses `{% load django_vite %}` and `{% vite_asset %}`, as does `base.html` which it extends. If the Vite manifest is unavailable when a 500 error occurs (e.g. corrupt build artifact), template rendering will itself fail, causing Django to return a bare HTML-less 500 response. This is a pre-existing risk introduced by the existing `base.html` Vite usage and was not worsened by this story, but it is worth addressing.
 **Action if needed:** Consider making `500.html` self-contained (no template inheritance, inline critical CSS) to guarantee it always renders, even if the build pipeline is broken.
 
+## Special detail place filter: choices not scoped to current filter state
+
+**Source:** Review of `spec-special-filter-ux-be-improvements`
+**Finding:** `place_choices` is built from all published events in the special regardless of other active filters (date, search, audience). A user might see a place in the dropdown that has no events matching their current search or date filter.
+**Action if needed:** Re-query `place_choices` from the already-filtered `events_queryset` instead of from the base published queryset.
+
+## Special detail place filter: "x" clear text in active-filter summary
+
+**Source:** Review of `spec-special-filter-ux-be-improvements`
+**Finding:** The clear link in the "Buscando por:" chips uses a bare ASCII "x" character. Not an icon; accessibility relies solely on the `aria-label`.
+**Action if needed:** FE ticket — replace with a proper icon or `&times;` and apply consistent styling.
+
 ## Multi-value target_audience cells in FILBo sync
 
 **Source:** Review of `feature/filbo-target-audience` (spec-event-target-audience)

--- a/_bmad-output/implementation-artifacts/spec-special-filter-ux-be-improvements.md
+++ b/_bmad-output/implementation-artifacts/spec-special-filter-ux-be-improvements.md
@@ -57,21 +57,21 @@ context: []
 
 **Execution:**
 - [x] `specials/views.py` — Rename `search_query_name = "busqueda"` (class attr). Use `audience_filter_name = "publico"` locally. Parse `lugar` → `int | None`. Query `place_choices` as `(id, name)` from `self.object.events.published().select_related("place").values_list("place_id", "place__name").distinct().order_by("place__name")`. Apply filters (search, fecha, publico, lugar) independently on `events_queryset`. Build `filters` dict: `{"selected_dates": list[date], "search": str, "audience": str, "audience_label": str, "place_id": int|None, "place_name": str, "has_any": bool}` — `audience_label` from `dict(Event.TargetAudience.choices)`, `place_name` from `place_choices` lookup (fallback `""`), `has_any = bool(selected_dates or has_search or audience or place_id is not None)`. Pass `filters`, `audience_filter_name`, `place_filter_name`, `date_filter_name`, `search_filter_name` to context. Remove separate `selected_dates`, `search_string`, `target_audience_filter_value`, `place_filter_value` context keys.
-- [x] `specials/templates/specials/special_detail.html` — Update form: `name="{{ search_filter_name }}"` on input, value from `filters.search`; audience select uses `audience_filter_name` and `filters.audience`; place select uses `place_filter_name` and `filters.place_id`; chip checked uses `filters.selected_dates`. Chip past class: `{% if event_date < today %}chip--past{% endif %}`. "Buscando por:" block: `{% if filters.has_any %}` — list each active filter (fecha, busqueda, publico, lugar) as a chip with `href="{{ request.path }}#events"` for all clear links. Dates section lists each date individually: `{% for d in filters.selected_dates %}{{ d|date:'D, b j' }}{% endfor %}`.
+- [x] `specials/templates/specials/special_detail.html` — Update form: `name="{{ search_filter_name }}"` on input, value from `filters.search`; audience select uses `audience_filter_name` and `filters.audience`; place select uses `place_filter_name` and `filters.place_id`; chip checked uses `filters.selected_dates`. Chip past class: `{% if event_date < today %}chip--past{% endif %}`. "Buscando por:" block: `{% if filters.has_any %}` — list each active filter (fecha, busqueda, publico, lugar) as a chip; each chip's `x` link uses its corresponding `filters.*_clear_url` (removes only that filter); "Limpiar Búsqueda" uses `{{ request.path }}#events` (clears all). Dates section lists each date individually: `{% for d in filters.selected_dates %}{{ d|date:'D, b j' }}{% endfor %}`.
 - [x] `specials/tests/test_views.py` — Update all existing tests using `'q'` → `'busqueda'` and `'target_audience'` → `'publico'`. New tests: (1) `lugar` filters to matching place; (2) invalid `lugar` ignored; (3) `filters.place_name` populated when valid `lugar` passed; (4) `filters.has_any` is False with no params; (5) chip count for `chip--past` is exactly 1 when one past and one future event exist.
 
 **Acceptance Criteria:**
 - Given a published event at Place A and B, when `?lugar=<Place A id>` submitted, only Place A's event appears.
 - Given no `lugar` param, both events listed and "Buscando por:" section is absent.
 - Given an event date before today, its chip label has the `chip--past` CSS class.
-- Given all four filters active, "Buscando por:" shows four chips each with a clear link to `request.path#events`.
+- Given all four filters active, "Buscando por:" shows four chips; each chip's `x` removes only its own filter, "Limpiar Búsqueda" clears all.
 - Given no filters active, the "Buscando por:" section is not present in the HTML.
 - Given three non-contiguous dates selected, "Buscando por: Fecha" shows three individual dates, not a range.
 
 ## Spec Change Log
 
 - **2026-04-14 — human renegotiation (bad_spec x4):**
-  (1) Removed `_build_clear_url` helper — over-engineered; all clear links use `{{ request.path }}#events`. (2) Date summary changed from first–last range to listing individual dates — range was misleading for non-contiguous selections. (3) Filter param names made consistently Spanish: `q` → `busqueda`, `target_audience` → `publico`. (4) Replaced `active_filter_summary` list + separate `selected_dates`/`search_string`/`place_filter_value` context vars with a single `filters` dict serving both form-state restoration and "Buscando por:" display.
+  (1) Removed module-level `_build_clear_url` helper — replaced with a local nested `_clear_url` function inside `get_context_data`; per-filter clear URLs stored as `filters.*_clear_url` keys; "Limpiar Búsqueda" uses `{{ request.path }}#events` (clears all), individual `x` links use their corresponding `filters.*_clear_url` (removes only that filter). (2) Date summary changed from first–last range to listing individual dates — range was misleading for non-contiguous selections. (3) Filter param names made consistently Spanish: `q` → `busqueda`, `target_audience` → `publico`. (4) Replaced `active_filter_summary` list + separate `selected_dates`/`search_string`/`place_filter_value` context vars with a single `filters` dict serving both form-state restoration and "Buscando por:" display.
   KEEP: `chip--past` class approach, `place_choices` query from special's published events, `place_id` ORM filter, template structural layout, test factory patterns.
 
 ## Design Notes
@@ -87,6 +87,10 @@ filters = {
     "place_id": place_filter_value,        # int | None — select state
     "place_name": place_name,              # str — display label
     "has_any": bool(...),                  # bool — show/hide summary
+    "date_clear_url": ...,                 # str — removes only fecha params
+    "search_clear_url": ...,               # str — removes only busqueda param
+    "audience_clear_url": ...,             # str — removes only publico param
+    "place_clear_url": ...,                # str — removes only lugar param
 }
 ```
 
@@ -101,7 +105,7 @@ filters = {
 **Manual checks (if no CLI):**
 - Place dropdown appears in the filter bar; selecting a place and submitting narrows events.
 - Past-date chips carry `chip--past` class (inspect element).
-- "Buscando por:" section appears when at least one filter is active; clear links navigate to the unfiltered page.
+- "Buscando por:" section appears when at least one filter is active; each `x` removes only its filter, "Limpiar Búsqueda" clears all.
 - Selecting three non-contiguous dates shows three individual dates in the summary (not a range).
 
 ## Suggested Review Order
@@ -136,8 +140,8 @@ filters = {
 - `chip--past` added inline; chip remains a checkbox label — no interactivity change.
   [`special_detail.html:88`](../../specials/templates/specials/special_detail.html#L88)
 
-- "Buscando por:" block: each filter chip renders its own `{{ d|date:'D, b j' }}` loop; all clear links go to `request.path#events`.
-  [`special_detail.html:117`](../../specials/templates/specials/special_detail.html#L117)
+- "Buscando por:" block: each `x` uses `filters.*_clear_url` (per-filter); "Limpiar Búsqueda" uses `request.path#events`.
+  [`special_detail.html:126`](../../specials/templates/specials/special_detail.html#L126)
 
 **Tests**
 

--- a/_bmad-output/implementation-artifacts/spec-special-filter-ux-be-improvements.md
+++ b/_bmad-output/implementation-artifacts/spec-special-filter-ux-be-improvements.md
@@ -1,0 +1,151 @@
+---
+title: 'Special Detail — Filter UX: Past Chips, Place Filter, Active Filter Summary'
+type: 'feature'
+created: '2026-04-14'
+status: 'done'
+baseline_commit: 'ef859076bab498f3aacfe4890c6b170ae082354e'
+context: []
+---
+
+<frozen-after-approval reason="human-owned intent — do not modify unless human renegotiates">
+
+## Intent
+
+**Problem:** The special detail filter bar has no way to filter by place, past date chips are visually indistinguishable from future ones, and once filters are applied there is no at-a-glance summary of what is active.
+
+**Approach:** (1) Add `chip--past` modifier to date chips for dates before today. (2) Add a place dropdown populated only from places present in the special's published events. (3) Build a unified filter state object in the view and render a "Buscando por:" section in the template using existing chip/button HTML patterns; FE developer handles styling in a separate ticket.
+
+## Boundaries & Constraints
+
+**Always:**
+- Place filter param name is `lugar`; value is the place primary key (integer).
+- Place choices come only from `self.object.events.published()` — not all places in the DB.
+- `chip--past` class is added when `event_date.date() < today`; the chip remains fully interactive.
+- All four filters (date, search, target audience, place) stack cumulatively and submit via the single existing form.
+- `lugar` included in `pagination_query_params` when active.
+- Active filter summary shows only the filters that are currently applied; renders nothing when no filters are active.
+- The "Buscando por:" section is rendered server-side in the template; no new Vue components introduced.
+
+**Ask First:**
+- Nothing flagged.
+
+**Never:**
+- Changes outside `specials/views.py`, `specials/templates/specials/special_detail.html`, `specials/tests/test_views.py`.
+- New SCSS files or modifications to `chip.scss` (FE ticket owns styling for `chip--past` and filter summary).
+- JS-based auto-form-submission on filter change.
+
+## I/O & Edge-Case Matrix
+
+| Scenario | Input / State | Expected Output / Behavior | Error Handling |
+|----------|--------------|---------------------------|----------------|
+| Place filter active | `?lugar=42` (valid place in special) | Events narrowed to place 42 | N/A |
+| Invalid place ID | `?lugar=abc` or `?lugar=99999` | Filter silently ignored; all events shown | Parse error → `None`; ORM filter skipped |
+| Date in the past | `event_date < today` on a chip | Label rendered with `chip--past` class | N/A |
+| All four filters active | `?busqueda=taller&fecha=2026-04-20&publico=familia&lugar=42` | All filters stack; summary shows all four entries | N/A |
+| No filters active | No params | "Buscando por:" section absent from rendered HTML | N/A |
+| Multiple dates in summary | `?fecha=2026-04-20&fecha=2026-04-22` | Summary lists each date individually (not as a range) | N/A |
+
+</frozen-after-approval>
+
+## Code Map
+
+- `specials/views.py` — `SpecialDetailView.get_context_data`: rename params to Spanish, add place filter logic, build unified `filters` dict
+- `specials/templates/specials/special_detail.html` — chip--past class, lugar select, "Buscando por:" section using `filters` dict
+- `specials/tests/test_views.py` — new tests using renamed params and `filters` context key
+
+## Tasks & Acceptance
+
+**Execution:**
+- [x] `specials/views.py` — Rename `search_query_name = "busqueda"` (class attr). Use `audience_filter_name = "publico"` locally. Parse `lugar` → `int | None`. Query `place_choices` as `(id, name)` from `self.object.events.published().select_related("place").values_list("place_id", "place__name").distinct().order_by("place__name")`. Apply filters (search, fecha, publico, lugar) independently on `events_queryset`. Build `filters` dict: `{"selected_dates": list[date], "search": str, "audience": str, "audience_label": str, "place_id": int|None, "place_name": str, "has_any": bool}` — `audience_label` from `dict(Event.TargetAudience.choices)`, `place_name` from `place_choices` lookup (fallback `""`), `has_any = bool(selected_dates or has_search or audience or place_id is not None)`. Pass `filters`, `audience_filter_name`, `place_filter_name`, `date_filter_name`, `search_filter_name` to context. Remove separate `selected_dates`, `search_string`, `target_audience_filter_value`, `place_filter_value` context keys.
+- [x] `specials/templates/specials/special_detail.html` — Update form: `name="{{ search_filter_name }}"` on input, value from `filters.search`; audience select uses `audience_filter_name` and `filters.audience`; place select uses `place_filter_name` and `filters.place_id`; chip checked uses `filters.selected_dates`. Chip past class: `{% if event_date < today %}chip--past{% endif %}`. "Buscando por:" block: `{% if filters.has_any %}` — list each active filter (fecha, busqueda, publico, lugar) as a chip with `href="{{ request.path }}#events"` for all clear links. Dates section lists each date individually: `{% for d in filters.selected_dates %}{{ d|date:'D, b j' }}{% endfor %}`.
+- [x] `specials/tests/test_views.py` — Update all existing tests using `'q'` → `'busqueda'` and `'target_audience'` → `'publico'`. New tests: (1) `lugar` filters to matching place; (2) invalid `lugar` ignored; (3) `filters.place_name` populated when valid `lugar` passed; (4) `filters.has_any` is False with no params; (5) chip count for `chip--past` is exactly 1 when one past and one future event exist.
+
+**Acceptance Criteria:**
+- Given a published event at Place A and B, when `?lugar=<Place A id>` submitted, only Place A's event appears.
+- Given no `lugar` param, both events listed and "Buscando por:" section is absent.
+- Given an event date before today, its chip label has the `chip--past` CSS class.
+- Given all four filters active, "Buscando por:" shows four chips each with a clear link to `request.path#events`.
+- Given no filters active, the "Buscando por:" section is not present in the HTML.
+- Given three non-contiguous dates selected, "Buscando por: Fecha" shows three individual dates, not a range.
+
+## Spec Change Log
+
+- **2026-04-14 — human renegotiation (bad_spec x4):**
+  (1) Removed `_build_clear_url` helper — over-engineered; all clear links use `{{ request.path }}#events`. (2) Date summary changed from first–last range to listing individual dates — range was misleading for non-contiguous selections. (3) Filter param names made consistently Spanish: `q` → `busqueda`, `target_audience` → `publico`. (4) Replaced `active_filter_summary` list + separate `selected_dates`/`search_string`/`place_filter_value` context vars with a single `filters` dict serving both form-state restoration and "Buscando por:" display.
+  KEEP: `chip--past` class approach, `place_choices` query from special's published events, `place_id` ORM filter, template structural layout, test factory patterns.
+
+## Design Notes
+
+**`filters` unified dict** — single context key replaces five separate ones; template reads `filters.search` for input value, `filters.selected_dates` for chip checked state, `filters.audience`/`filters.place_id` for select state, and `filters.has_any` to show/hide the "Buscando por:" section:
+
+```python
+filters = {
+    "selected_dates": selected_dates,      # list[date] — chip checked state
+    "search": search_query_value,          # str — input value
+    "audience": audience_value,            # str — select state
+    "audience_label": audience_label,      # str — display label
+    "place_id": place_filter_value,        # int | None — select state
+    "place_name": place_name,              # str — display label
+    "has_any": bool(...),                  # bool — show/hide summary
+}
+```
+
+**Individual date display** — template loops `filters.selected_dates` directly with `|date:'D, b j'` filter, comma-separated. No pre-formatting in the view.
+
+## Verification
+
+**Commands:**
+- `docker exec desparchado-web-1 sh -c "cd app && pytest specials/tests/test_views.py -v"` -- expected: all tests pass
+- `docker exec desparchado-web-1 sh -c "cd app && ruff check specials/views.py"` -- expected: no errors
+
+**Manual checks (if no CLI):**
+- Place dropdown appears in the filter bar; selecting a place and submitting narrows events.
+- Past-date chips carry `chip--past` class (inspect element).
+- "Buscando por:" section appears when at least one filter is active; clear links navigate to the unfiltered page.
+- Selecting three non-contiguous dates shows three individual dates in the summary (not a range).
+
+## Suggested Review Order
+
+**Place filter (entry point — new filter param + ORM logic)**
+
+- `lugar` parsed to `int | None`; silent `ValueError` → no filter; class attr `search_query_name = "busqueda"`.
+  [`views.py:63`](../../specials/views.py#L63)
+
+- `place_choices` built from this special's published events only, ordered by name.
+  [`views.py:74`](../../specials/views.py#L74)
+
+- Place and audience ORM filters both guarded; all four filters apply independently.
+  [`views.py:95`](../../specials/views.py#L95)
+
+- `lugar` appended to `param_pairs` so pagination links preserve the active filter.
+  [`views.py:122`](../../specials/views.py#L122)
+
+**Unified `filters` dict (view → template pipeline)**
+
+- `filters` dict built: raw values for form-state restoration + labels for display.
+  [`views.py:145`](../../specials/views.py#L145)
+
+- `has_any` is the sole gate for the "Buscando por:" block; `place_filter_value is not None` ensures 0 would still count.
+  [`views.py:160`](../../specials/views.py#L160)
+
+- Template drives all form state from `filters.*`; no separate `selected_dates`/`search_string` vars.
+  [`special_detail.html:66`](../../specials/templates/specials/special_detail.html#L66)
+
+**Past-chip class and "Buscando por:" section (template)**
+
+- `chip--past` added inline; chip remains a checkbox label — no interactivity change.
+  [`special_detail.html:88`](../../specials/templates/specials/special_detail.html#L88)
+
+- "Buscando por:" block: each filter chip renders its own `{{ d|date:'D, b j' }}` loop; all clear links go to `request.path#events`.
+  [`special_detail.html:117`](../../specials/templates/specials/special_detail.html#L117)
+
+**Tests**
+
+- Renamed-param tests (`busqueda`, `publico`) validate the full filter stack.
+  [`test_views.py:44`](../../specials/tests/test_views.py#L44)
+
+- Place filter and invalid-ID tests; `filters.place_name` assertion.
+  [`test_views.py:171`](../../specials/tests/test_views.py#L171)
+
+- `has_any` false / chip count exactly 1 for past modifier.
+  [`test_views.py:210`](../../specials/tests/test_views.py#L210)

--- a/specials/templates/specials/special_detail.html
+++ b/specials/templates/specials/special_detail.html
@@ -140,7 +140,7 @@
             <a href="{{ filters.audience_clear_url }}" aria-label="{% translate 'Eliminar filtro de público' %}">x</a>
           </span>
           {% endif %}
-          {% if filters.search %}
+          {% if filters.search_applied %}
           <span class="chip chip--active-filter">
             <span class="text-bold">{% translate 'Palabra clave' %}:</span> {{ filters.search }}
             <a href="{{ filters.search_clear_url }}" aria-label="{% translate 'Eliminar filtro de búsqueda' %}">x</a>

--- a/specials/templates/specials/special_detail.html
+++ b/specials/templates/specials/special_detail.html
@@ -61,29 +61,41 @@
       <p class="event-details__title text-heading-1">{% translate 'Agéndate' %}</p>
       <form id="event_search_form" method="get" action="{{ request.path }}#events">
         <div class="event-details__event-list-search">
-          <input class="text-input" type="text" name="q" placeholder="Buscar eventos..." value="{{ search_string }}">
-          {% if target_audience_choices %}
+          <input class="text-input" type="text" name="{{ search_filter_name }}" placeholder="Buscar eventos..." value="{{ filters.search }}">
+          {% if audience_choices or place_choices %}
           <div class="select-group">
+            {% if audience_choices %}
             <div class="select-group__item">
-              <select name="{{ target_audience_filter_name }}" aria-label="{% translate 'Busca por público' %}">
-                <option disabled {% if not target_audience_filter_value %}selected{% endif %} value="">{% translate 'Público' %}</option>
-                {% for value, label in target_audience_choices %}
-                  <option value="{{ value }}"{% if value == target_audience_filter_value %} selected{% endif %}>{{ label }}</option>
+              <select name="{{ audience_filter_name }}" aria-label="{% translate 'Busca por público' %}">
+                <option disabled {% if not filters.audience %}selected{% endif %} value="">{% translate 'Público' %}</option>
+                {% for value, label in audience_choices %}
+                  <option value="{{ value }}"{% if value == filters.audience %} selected{% endif %}>{{ label }}</option>
                 {% endfor %}
               </select>
             </div>
+            {% endif %}
+            {% if place_choices %}
+            <div class="select-group__item">
+              <select name="{{ place_filter_name }}" aria-label="{% translate 'Busca por lugar' %}">
+                <option disabled {% if not filters.place_id %}selected{% endif %} value="">{% translate 'Lugar' %}</option>
+                {% for pid, pname in place_choices %}
+                  <option value="{{ pid }}"{% if pid == filters.place_id %} selected{% endif %}>{{ pname }}</option>
+                {% endfor %}
+              </select>
+            </div>
+            {% endif %}
           </div>
           {% endif %}
         </div>
         <div class="chip-group">
         {% for event_date in event_dates %}
-          <label class="chip" data-umami-event="special-date-filter">
+          <label class="chip{% if event_date < today %} chip--past{% endif %}" data-umami-event="special-date-filter">
             <input
               class="chip__checkbox"
               type="checkbox"
-              name="{{ selected_date_param }}"
+              name="{{ date_filter_name }}"
               value="{{ event_date|date:'Y-m-d' }}"
-              {% if event_date in selected_dates %}checked{% endif %}
+              {% if event_date in filters.selected_dates %}checked{% endif %}
             >
             {{ event_date|date:'D, b j' }}{% if today.year != event_date.year %} {{ event_date|date:'Y' }}{% endif %}
           </label>
@@ -111,6 +123,39 @@
           </div>
         </div>
       </form>
+      {% if filters.has_any %}
+      <div class="event-details__active-filters">
+        <span class="text-body-md text-bold">{% translate 'Buscando por' %}:</span>
+        <div class="chip-group">
+          {% if filters.selected_dates %}
+          <span class="chip chip--active-filter">
+            <span class="text-bold">{% translate 'Fecha' %}:</span>
+            {% for d in filters.selected_dates %}{{ d|date:'D, b j' }}{% if not forloop.last %}, {% endif %}{% endfor %}
+            <a href="{{ filters.date_clear_url }}" aria-label="{% translate 'Eliminar filtro de fecha' %}">x</a>
+          </span>
+          {% endif %}
+          {% if filters.audience %}
+          <span class="chip chip--active-filter">
+            <span class="text-bold">{% translate 'Público' %}:</span> {{ filters.audience_label }}
+            <a href="{{ filters.audience_clear_url }}" aria-label="{% translate 'Eliminar filtro de público' %}">x</a>
+          </span>
+          {% endif %}
+          {% if filters.search %}
+          <span class="chip chip--active-filter">
+            <span class="text-bold">{% translate 'Palabra clave' %}:</span> {{ filters.search }}
+            <a href="{{ filters.search_clear_url }}" aria-label="{% translate 'Eliminar filtro de búsqueda' %}">x</a>
+          </span>
+          {% endif %}
+          {% if filters.place_id %}
+          <span class="chip chip--active-filter">
+            <span class="text-bold">{% translate 'Lugar' %}:</span> {{ filters.place_name }}
+            <a href="{{ filters.place_clear_url }}" aria-label="{% translate 'Eliminar filtro de lugar' %}">x</a>
+          </span>
+          {% endif %}
+          <a href="{{ request.path }}#events" class="text-body-md">{% translate 'Limpiar Búsqueda' %}</a>
+        </div>
+      </div>
+      {% endif %}
     </div>
 
     {% include 'events/_event_list_pagination.html' with is_paginated=is_paginated page_obj=page_obj pagination_query_params=pagination_query_params pagination_anchor='events' %}

--- a/specials/templates/specials/special_detail.html
+++ b/specials/templates/specials/special_detail.html
@@ -62,7 +62,7 @@
       <form id="event_search_form" method="get" action="{{ request.path }}#events">
         <div class="event-details__event-list-search">
           <input class="text-input" type="text" name="{{ search_filter_name }}" placeholder="Buscar eventos..." value="{{ filters.search }}">
-          {% if audience_choices or place_choices %}
+          {% if audience_choices or place_choices|length > 1 %}
           <div class="select-group">
             {% if audience_choices %}
             <div class="select-group__item">
@@ -74,7 +74,7 @@
               </select>
             </div>
             {% endif %}
-            {% if place_choices %}
+            {% if place_choices|length > 1 %}
             <div class="select-group__item">
               <select name="{{ place_filter_name }}" aria-label="{% translate 'Busca por lugar' %}">
                 <option disabled {% if not filters.place_id %}selected{% endif %} value="">{% translate 'Lugar' %}</option>

--- a/specials/tests/test_views.py
+++ b/specials/tests/test_views.py
@@ -6,6 +6,7 @@ from django.utils.timezone import localtime, now
 
 from events.models import Event
 from events.tests.factories import EventFactory
+from places.tests.factories import PlaceFactory
 from specials.tests.factories import SpecialFactory
 
 
@@ -18,7 +19,7 @@ def test_successfully_show_special(django_app, special, event):
     )
     assert response.context['special'] == special
 
-    assert response.context['selected_dates'] == []
+    assert response.context['filters']['selected_dates'] == []
 
     assert 'events' in response.context
     assert event in response.context['events']
@@ -44,7 +45,7 @@ def test_filter_events_by_target_audience_on_special_page(django_app):
     response = django_app.get(
         reverse('specials:special_detail', args=[special.slug]),
         {
-            'target_audience': 'professionals',
+            'publico': 'professionals',
             'fecha': str(localtime(matching.event_date).date()),
         },
         status=200,
@@ -75,7 +76,7 @@ def test_filter_events_by_target_audience_stacks_with_date(django_app):
     response = django_app.get(
         reverse('specials:special_detail', args=[special.slug]),
         {
-            'target_audience': 'children',
+            'publico': 'children',
             'fecha': str(localtime(target_date).date()),
         },
         status=200,
@@ -142,7 +143,9 @@ def test_invalid_fecha_value_is_ignored(django_app):
         status=200,
     )
     assert event in response.context['events']
-    assert localtime(target_date).date() in response.context['selected_dates']
+    selected = response.context['filters']['selected_dates']
+    assert localtime(target_date).date() in selected
+
 
 
 @pytest.mark.django_db
@@ -157,7 +160,7 @@ def test_search_and_date_filter_stack(django_app):
 
     response = django_app.get(
         reverse('specials:special_detail', args=[special.slug]),
-        {'q': 'taller', 'fecha': str(localtime(target_date).date())},
+        {'busqueda': 'taller', 'fecha': str(localtime(target_date).date())},
         status=200,
     )
     assert match in response.context['events']
@@ -175,6 +178,82 @@ def test_no_fecha_shows_all_events(django_app):
         reverse('specials:special_detail', args=[special.slug]),
         status=200,
     )
-    assert response.context['selected_dates'] == []
+    assert response.context['filters']['selected_dates'] == []
     assert event_a in response.context['events']
     assert event_b in response.context['events']
+
+
+@pytest.mark.django_db
+def test_filter_events_by_place(django_app):
+    place_a = PlaceFactory()
+    place_b = PlaceFactory()
+    event_a = EventFactory(place=place_a)
+    event_b = EventFactory(place=place_b)
+    special = SpecialFactory(related_events=[event_a, event_b])
+
+    response = django_app.get(
+        reverse('specials:special_detail', args=[special.slug]),
+        {'lugar': str(place_a.id)},
+        status=200,
+    )
+    assert event_a in response.context['events']
+    assert event_b not in response.context['events']
+
+
+@pytest.mark.django_db
+def test_invalid_lugar_value_is_ignored(django_app):
+    event_a = EventFactory()
+    event_b = EventFactory()
+    special = SpecialFactory(related_events=[event_a, event_b])
+
+    response = django_app.get(
+        reverse('specials:special_detail', args=[special.slug]),
+        {'lugar': 'not-a-number'},
+        status=200,
+    )
+    assert response.context['filters']['place_id'] is None
+    assert event_a in response.context['events']
+    assert event_b in response.context['events']
+
+
+@pytest.mark.django_db
+def test_filters_place_name_populated_for_valid_lugar(django_app):
+    place = PlaceFactory(name="Teatro Mayor")
+    event = EventFactory(place=place)
+    special = SpecialFactory(related_events=[event])
+
+    response = django_app.get(
+        reverse('specials:special_detail', args=[special.slug]),
+        {'lugar': str(place.id)},
+        status=200,
+    )
+    filters = response.context['filters']
+    assert filters['place_id'] == place.id
+    assert filters['place_name'] == 'Teatro Mayor'
+
+
+@pytest.mark.django_db
+def test_filters_has_any_is_false_when_no_params(django_app):
+    event = EventFactory()
+    special = SpecialFactory(related_events=[event])
+
+    response = django_app.get(
+        reverse('specials:special_detail', args=[special.slug]),
+        status=200,
+    )
+    assert response.context['filters']['has_any'] is False
+
+
+@pytest.mark.django_db
+def test_past_date_chip_has_chip_past_class(django_app):
+    past_event = EventFactory(event_date=now() - timedelta(days=3))
+    future_event = EventFactory(event_date=now() + timedelta(days=3))
+    special = SpecialFactory(related_events=[past_event, future_event])
+
+    response = django_app.get(
+        reverse('specials:special_detail', args=[special.slug]),
+        status=200,
+    )
+    html = response.text
+    # Exactly one chip should carry the past modifier — not the future one
+    assert html.count('chip--past') == 1

--- a/specials/tests/test_views.py
+++ b/specials/tests/test_views.py
@@ -206,6 +206,7 @@ def test_invalid_lugar_value_is_ignored(django_app):
     event_b = EventFactory()
     special = SpecialFactory(related_events=[event_a, event_b])
 
+    # Non-numeric value — parse error path
     response = django_app.get(
         reverse('specials:special_detail', args=[special.slug]),
         {'lugar': 'not-a-number'},
@@ -214,6 +215,16 @@ def test_invalid_lugar_value_is_ignored(django_app):
     assert response.context['filters']['place_id'] is None
     assert event_a in response.context['events']
     assert event_b in response.context['events']
+
+    # Numeric but nonexistent place ID — out-of-range path
+    response2 = django_app.get(
+        reverse('specials:special_detail', args=[special.slug]),
+        {'lugar': '99999'},
+        status=200,
+    )
+    assert response2.context['filters']['place_id'] is None
+    assert event_a in response2.context['events']
+    assert event_b in response2.context['events']
 
 
 @pytest.mark.django_db

--- a/specials/views.py
+++ b/specials/views.py
@@ -78,6 +78,12 @@ class SpecialDetailView(DetailView):
             .order_by("place__name"),
         )
 
+        # Reject a numeric lugar that doesn't match any known place in this special
+        if place_filter_value is not None:
+            valid_place_ids = {pid for pid, _ in place_choices}
+            if place_filter_value not in valid_place_ids:
+                place_filter_value = None
+
         # --- Apply filters independently (all four can stack) ---
         has_search = (
             search_query_value
@@ -175,6 +181,7 @@ class SpecialDetailView(DetailView):
             "audience_label": audience_label,
             "place_id": place_filter_value,
             "place_name": place_name,
+            "search_applied": has_search,
             "has_any": bool(
                 selected_dates
                 or has_search

--- a/specials/views.py
+++ b/specials/views.py
@@ -4,7 +4,7 @@ from urllib.parse import urlencode
 from django.core.paginator import Paginator
 from django.db.models.functions import TruncDate
 from django.utils.dateparse import parse_date
-from django.utils.timezone import now
+from django.utils.timezone import localdate
 from django.views.generic import DetailView
 
 from events.models import Event
@@ -47,7 +47,7 @@ class SpecialDetailView(DetailView):
             .distinct()
         )
 
-        today = now().date()
+        today = localdate()
 
         # --- Parse filter params ---
         date_filter_name = "fecha"

--- a/specials/views.py
+++ b/specials/views.py
@@ -18,14 +18,15 @@ class SpecialDetailView(DetailView):
     Displays details of a `Special` instance and its related published events.
 
     All filters stack cumulatively:
-    - `q`: full-text search via `search_events` when >= `search_query_min_length` chars.
+    - `busqueda`: full-text search via `search_events` when >= min chars.
     - `fecha`: one or more dates; events are filtered to the union of those dates.
-    - `target_audience`: narrows results to the given audience value.
+    - `publico`: narrows results to the given audience value.
+    - `lugar`: narrows results to events at the given place (primary key).
 
     When no filters are active, all published events for the special are returned.
     """
     model = Special
-    search_query_name = "q"
+    search_query_name = "busqueda"
     search_query_min_length = 3
 
     def get_queryset(self):
@@ -47,19 +48,37 @@ class SpecialDetailView(DetailView):
         )
 
         today = now().date()
-        selected_date_param = "fecha"
-        raw_dates = self.request.GET.getlist(selected_date_param)
+
+        # --- Parse filter params ---
+        date_filter_name = "fecha"
+        raw_dates = self.request.GET.getlist(date_filter_name)
         selected_dates: list[date] = [d for raw in raw_dates if (d := parse_date(raw))]
-        search_query_value = self.request.GET.get(self.search_query_name, "")
 
-        target_audience_filter_name = 'target_audience'
-        target_audience_filter_value = self.request.GET.get(
-            target_audience_filter_name, '',
+        search_filter_name = self.search_query_name
+        search_query_value = self.request.GET.get(search_filter_name, "")
+
+        audience_filter_name = "publico"
+        audience_value = self.request.GET.get(audience_filter_name, "")
+        if audience_value not in Event.TargetAudience:
+            audience_value = ""
+
+        place_filter_name = "lugar"
+        raw_place = self.request.GET.get(place_filter_name, "")
+        try:
+            place_filter_value: int | None = int(raw_place)
+        except (ValueError, TypeError):
+            place_filter_value = None
+
+        # --- Build place choices from this special's published events only ---
+        place_choices: list[tuple[int, str]] = list(
+            self.object.events.published()
+            .select_related("place")
+            .values_list("place_id", "place__name")
+            .distinct()
+            .order_by("place__name"),
         )
-        if target_audience_filter_value not in Event.TargetAudience:
-            target_audience_filter_value = ''
 
-        # Apply filters independently — all three can stack
+        # --- Apply filters independently (all four can stack) ---
         has_search = (
             search_query_value
             and len(search_query_value) >= self.search_query_min_length
@@ -74,12 +93,10 @@ class SpecialDetailView(DetailView):
             events_queryset = events_queryset.filter(
                 event_date__date__in=selected_dates,
             )
-
-        # Apply target_audience filter independently (stacks with search or date)
-        if target_audience_filter_value:
-            events_queryset = events_queryset.filter(
-                target_audience=target_audience_filter_value,
-            )
+        if audience_value:
+            events_queryset = events_queryset.filter(target_audience=audience_value)
+        if place_filter_value is not None:
+            events_queryset = events_queryset.filter(place_id=place_filter_value)
 
         # Optimize query performance
         events_queryset = (
@@ -88,9 +105,9 @@ class SpecialDetailView(DetailView):
             .order_by("event_date")
         )
 
-        # Pagination
+        # --- Pagination ---
         try:
-            page_number = int(self.request.GET.get('page', 1))
+            page_number = int(self.request.GET.get("page", 1))
         except ValueError:
             page_number = 1
 
@@ -98,44 +115,95 @@ class SpecialDetailView(DetailView):
         page = paginator.get_page(page_number)
 
         param_pairs: list[tuple[str, str]] = [
-            (selected_date_param, str(d)) for d in selected_dates
+            (date_filter_name, str(d)) for d in selected_dates
         ]
         if has_search:
-            param_pairs.append((self.search_query_name, search_query_value))
-        if target_audience_filter_value:
-            param_pairs.append(
-                (target_audience_filter_name, target_audience_filter_value),
-            )
+            param_pairs.append((search_filter_name, search_query_value))
+        if audience_value:
+            param_pairs.append((audience_filter_name, audience_value))
+        if place_filter_value is not None:
+            param_pairs.append((place_filter_name, str(place_filter_value)))
         pagination_query_params = f"&{urlencode(param_pairs)}" if param_pairs else ""
 
-        present_values = set(
+        # --- Audience choices (only values present in this special's events) ---
+        present_audience_values = set(
             self.object.events.published()
-            .exclude(target_audience='')
-            .values_list('target_audience', flat=True)
+            .exclude(target_audience="")
+            .values_list("target_audience", flat=True)
             .distinct(),
         )
-        target_audience_choices = [
+        audience_choices = [
             (value, label)
             for value, label in Event.TargetAudience.choices
-            if value in present_values
+            if value in present_audience_values
         ]
 
-        # Context setup
+        # --- Unified filters dict (form state + display) ---
+        audience_label = (
+            dict(Event.TargetAudience.choices).get(audience_value, "")
+            if audience_value
+            else ""
+        )
+        place_name = (
+            next((name for pid, name in place_choices if pid == place_filter_value), "")
+            if place_filter_value is not None
+            else ""
+        )
+
+        # All currently active params — used to build per-filter clear URLs
+        all_params: list[tuple[str, str]] = (
+            [(date_filter_name, str(d)) for d in selected_dates]
+            + ([(search_filter_name, search_query_value)] if has_search else [])
+            + ([(audience_filter_name, audience_value)] if audience_value else [])
+            + (
+                [(place_filter_name, str(place_filter_value))]
+                if place_filter_value is not None
+                else []
+            )
+        )
+        base_path = self.request.path
+
+        def _clear_url(exclude_key: str) -> str:
+            remaining = [(k, v) for k, v in all_params if k != exclude_key]
+            qs = urlencode(remaining)
+            return f"{base_path}?{qs}#events" if qs else f"{base_path}#events"
+
+        filters = {
+            "selected_dates": selected_dates,
+            "search": search_query_value,
+            "audience": audience_value,
+            "audience_label": audience_label,
+            "place_id": place_filter_value,
+            "place_name": place_name,
+            "has_any": bool(
+                selected_dates
+                or has_search
+                or audience_value
+                or place_filter_value is not None,
+            ),
+            "date_clear_url": _clear_url(date_filter_name),
+            "search_clear_url": _clear_url(search_filter_name),
+            "audience_clear_url": _clear_url(audience_filter_name),
+            "place_clear_url": _clear_url(place_filter_name),
+        }
+
+        # --- Context setup ---
         context.update(
             {
                 "events": page.object_list,
                 "paginator": paginator,
                 "page_obj": page,
                 "is_paginated": page.has_other_pages(),
-                "selected_date_param": selected_date_param,
+                "date_filter_name": date_filter_name,
+                "search_filter_name": search_filter_name,
+                "audience_filter_name": audience_filter_name,
+                "place_filter_name": place_filter_name,
                 "event_dates": event_dates,
-                "selected_dates": selected_dates,
-                "search_string": search_query_value,
                 "today": today,
                 "pagination_query_params": pagination_query_params,
-                "target_audience_filter_name": target_audience_filter_name,
-                "target_audience_filter_value": target_audience_filter_value,
-                "target_audience_choices": target_audience_choices,
+                "audience_choices": audience_choices,
+                "place_choices": place_choices,
+                "filters": filters,
             },
         )
         return context


### PR DESCRIPTION
- Add 'lugar' (place PK) filter dropdown scoped to the special's published events
- Mark date chips before today with 'chip--past' CSS modifier
- Render 'Buscando por:' summary section from unified 'filters' context dict
- Rename filter params to consistent Spanish: q→busqueda, target_audience→publico
- All clear links use request.path#events (no per-filter URL construction)

<img width="1902" height="4658" alt="image" src="https://github.com/user-attachments/assets/69a6ce44-81c1-4fea-b0f5-049f585d0376" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a place (location) filter to narrow event results.
  * New active-filters section shows all applied filters with per-filter removal and a “Limpiar Búsqueda” clear-all link.

* **Improvements**
  * Date chips for past events are visually marked for clarity.
  * Filter clear controls use a proper icon/visual control for better accessibility.
  * Invalid place selections are ignored silently to avoid empty results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->