### PR TITLE
[FIX][NA] Fix DataError on search queries containing NUL bytes (Sentry #7467344276)

### DIFF
--- a/desparchado/tests/test_utils_sanitize_text_input.py
+++ b/desparchado/tests/test_utils_sanitize_text_input.py
@@ -1,0 +1,16 @@
+import pytest
+
+from ..utils import sanitize_text_input
+
+
+def test_nul_byte_is_removed():
+    assert sanitize_text_input("hello\x00world") == "helloworld"
+
+
+@pytest.mark.parametrize("safe_char", ["\t", "\n", "\r"])
+def test_safe_whitespace_is_preserved(safe_char):
+    assert sanitize_text_input(safe_char) == safe_char
+
+
+def test_only_control_chars_returns_empty_string():
+    assert sanitize_text_input("\x00\x01\x02\x03\x1f") == ""

--- a/desparchado/utils.py
+++ b/desparchado/utils.py
@@ -1,5 +1,6 @@
 import calendar
 import logging
+import unicodedata
 from datetime import date, timedelta
 
 from django.conf import settings
@@ -141,6 +142,29 @@ def send_notification(request, obj, model_name, created):
     except Exception as e:  # pylint: disable=broad-exception-caught
         logger.info(subject, extra={'message': message})
         logger.exception('No se pudo enviar correo electrónico', exc_info=e)
+
+
+_SAFE_CONTROL_CHARS = {'\t', '\n', '\r'}
+
+
+def sanitize_text_input(value: str) -> str:
+    """
+    Strips control characters from a string before passing it to PostgreSQL.
+
+    PostgreSQL text fields reject NUL bytes (0x00), and other C0/C1 control
+    characters (Unicode category 'Cc') are equally invalid in user-facing search
+    queries. Tab, newline, and carriage return are preserved.
+
+    Args:
+        value: Raw string received from user input.
+
+    Returns:
+        Cleaned string safe for PostgreSQL text fields and full-text search.
+    """
+    return ''.join(
+        c for c in value
+        if c in _SAFE_CONTROL_CHARS or unicodedata.category(c) != 'Cc'
+    )
 
 
 def sanitize_html(html: str):

--- a/events/services/event_search.py
+++ b/events/services/event_search.py
@@ -3,6 +3,7 @@ from typing import TypeVar
 from django.contrib.postgres.search import SearchQuery, SearchVector
 from django.db.models import Q, QuerySet
 
+from desparchado.utils import sanitize_text_input
 from events.models import Event
 
 EventQuerySet = TypeVar("EventQuerySet", bound=QuerySet[Event])
@@ -29,6 +30,7 @@ def search_events(
     Returns:
         A filtered QuerySet containing Events that match the search criteria.
     """
+    search_str = sanitize_text_input(search_str)
     if not search_str or len(search_str) < search_str_min_length:
         return queryset
 

--- a/events/views/organizer_autocomplete.py
+++ b/events/views/organizer_autocomplete.py
@@ -1,6 +1,7 @@
 import logging
 
 from desparchado.autocomplete import BaseAutocomplete
+from desparchado.utils import sanitize_text_input
 from events.models import Organizer
 
 logger = logging.getLogger(__name__)
@@ -16,6 +17,6 @@ class OrganizerAutocompleteView(BaseAutocomplete):
         qs = Organizer.objects.order_by('name').all()
 
         if self.q:
-            qs = qs.filter(name__unaccent__icontains=self.q)
+            qs = qs.filter(name__unaccent__icontains=sanitize_text_input(self.q))
 
         return qs

--- a/events/views/organizer_suggestion.py
+++ b/events/views/organizer_suggestion.py
@@ -6,6 +6,7 @@ from django.utils.html import escape
 from django.utils.safestring import mark_safe
 from django.views import View
 
+from desparchado.utils import sanitize_text_input
 from events.models import Organizer
 
 logger = logging.getLogger(__name__)
@@ -14,7 +15,7 @@ logger = logging.getLogger(__name__)
 class OrganizerSuggestionsView(LoginRequiredMixin, View):
 
     def get(self, request):
-        query = request.GET.get('query', '')
+        query = sanitize_text_input(request.GET.get('query', ''))
         suggestion = None
         if len(query) >= 5:
             organizers = Organizer.objects.filter(

--- a/events/views/speaker_autocomplete.py
+++ b/events/views/speaker_autocomplete.py
@@ -3,6 +3,7 @@ import logging
 from django.utils.html import format_html
 
 from desparchado.autocomplete import BaseAutocomplete
+from desparchado.utils import sanitize_text_input
 from events.models import Speaker
 
 logger = logging.getLogger(__name__)
@@ -23,6 +24,6 @@ class SpeakerAutocomplete(BaseAutocomplete):
         qs = Speaker.objects.order_by('name').all()
 
         if self.q:
-            qs = qs.filter(name__unaccent__icontains=self.q)
+            qs = qs.filter(name__unaccent__icontains=sanitize_text_input(self.q))
 
         return qs

--- a/events/views/speaker_list.py
+++ b/events/views/speaker_list.py
@@ -4,6 +4,7 @@ from django.contrib.postgres.search import SearchVector
 from django.db.models import Q
 from django.views.generic import ListView
 
+from desparchado.utils import sanitize_text_input
 from events.models import Speaker
 
 logger = logging.getLogger(__name__)
@@ -17,7 +18,7 @@ class SpeakerListView(ListView):
     q = ''
 
     def dispatch(self, request, *args, **kwargs):
-        self.q = request.GET.get('q', '')
+        self.q = sanitize_text_input(request.GET.get('q', ''))
         return super().dispatch(request, *args, **kwargs)
 
     def get_queryset(self):

--- a/places/views/place_autocomplete.py
+++ b/places/views/place_autocomplete.py
@@ -1,4 +1,5 @@
 from desparchado.autocomplete import BaseAutocomplete
+from desparchado.utils import sanitize_text_input
 from places.models import Place
 
 
@@ -12,6 +13,6 @@ class PlaceAutocompleteView(BaseAutocomplete):
         qs = Place.objects.order_by('name').all()
 
         if self.q:
-            qs = qs.filter(name__unaccent__icontains=self.q)
+            qs = qs.filter(name__unaccent__icontains=sanitize_text_input(self.q))
 
         return qs


### PR DESCRIPTION
Adds sanitize_text_input() to desparchado/utils.py which strips Unicode Cc control characters (including 0x00) from user input before it reaches PostgreSQL. search_events() now sanitizes the query string at the service boundary, protecting all callers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search and autocomplete features now sanitize user input to improve handling of special characters across event searches, organizer suggestions, speaker results, and place searches.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cansadadeserfeliz/desparchado/pull/688)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->