### PR TITLE
[FIX][NA] Limit RSS feed size and switch sitemap to index pattern to prevent gunicorn worker kills

### DIFF
--- a/desparchado/sitemap.py
+++ b/desparchado/sitemap.py
@@ -88,7 +88,7 @@ class SpecialSitemap(sitemaps.Sitemap):
     priority = 0.9
 
     def items(self):
-        return Special.objects.filter(is_published=True)
+        return Special.objects.filter(is_published=True).order_by('-modified')
 
     def lastmod(self, item):
         return item.modified

--- a/desparchado/tests/test_views.py
+++ b/desparchado/tests/test_views.py
@@ -43,5 +43,26 @@ def test_about_page(django_app):
 
 
 @pytest.mark.django_db
-def test_sitemap(django_app, event, place, organizer, speaker, blog_post, special):
-    django_app.get(reverse('django.contrib.sitemaps.views.sitemap'), status=200)
+def test_sitemap_index(
+    django_app, event, place, organizer, speaker, blog_post, special,
+):
+    url = reverse('django.contrib.sitemaps.views.index')
+    response = django_app.get(url, status=200)
+    assert b'sitemap-events.xml' in response.body
+    assert b'sitemap-places.xml' in response.body
+
+
+@pytest.mark.django_db
+def test_sitemap_section_events(django_app, event):
+    django_app.get(
+        reverse('django.contrib.sitemaps.views.sitemap', kwargs={'section': 'events'}),
+        status=200,
+    )
+
+
+@pytest.mark.django_db
+def test_sitemap_section_places(django_app, place):
+    django_app.get(
+        reverse('django.contrib.sitemaps.views.sitemap', kwargs={'section': 'places'}),
+        status=200,
+    )

--- a/desparchado/urls.py
+++ b/desparchado/urls.py
@@ -18,6 +18,7 @@ from django.conf import settings
 from django.conf.urls import include
 from django.conf.urls.static import static
 from django.contrib import admin
+from django.contrib.sitemaps.views import index as sitemap_index
 from django.contrib.sitemaps.views import sitemap
 from django.urls import path
 from django.views.generic import TemplateView
@@ -102,6 +103,12 @@ urlpatterns = [
 
     path(
         'sitemap.xml',
+        sitemap_index,
+        {'sitemaps': sitemaps},
+        name='django.contrib.sitemaps.views.index',
+    ),
+    path(
+        'sitemap-<section>.xml',
         sitemap,
         {'sitemaps': sitemaps},
         name='django.contrib.sitemaps.views.sitemap',

--- a/desparchado/views/rss.py
+++ b/desparchado/views/rss.py
@@ -22,6 +22,8 @@ class RssSiteEventsFeed(Feed):
 
 
 class SocialNetworksRssSiteEventsFeed(Feed):
+    """RSS feed of scheduled social posts for Zapier-driven event announcements."""
+
     title = 'Eventos en Desparchado.co'
     link = '/events/'
     description = 'Futuros eventos en Desparchado.co'
@@ -56,13 +58,14 @@ class SocialNetworksRssSiteEventsFeed(Feed):
                 event__is_published=True,
                 event__is_approved=True,
                 published_at__lte=timezone.now(),
-                published_at__gte=timezone.datetime(2019, 2, 27),
             )
             .select_related('event')
-            .order_by('published_at')
+            .order_by('-published_at')[:20]
         )
 
 
 class AtomSiteEventsFeed(RssSiteEventsFeed):
+    """Atom 1.0 variant of RssSiteEventsFeed."""
+
     feed_type = Atom1Feed
     subtitle = RssSiteEventsFeed.description


### PR DESCRIPTION
- Cap SocialNetworksRssSiteEventsFeed to 20 most recent posts (was unbounded since 2019)
- Switch /sitemap.xml to sitemap index view; each section served at /sitemap-<section>.xml
- Add ordering to SpecialSitemap to avoid UnorderedObjectListWarning
- Update and expand sitemap tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sitemap restructured with index and dedicated sections for events and places discovery
  * Events RSS feed now displays up to 20 most recent items (previously 10)
  * Special records in sitemap ordered by most recent modifications

* **Tests**
  * Improved sitemap test coverage with focused tests for index and section endpoints

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cansadadeserfeliz/desparchado/pull/691)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->