### PR TITLE
[NA][NA] Downgrade vitest to ^3.1.2 to fix npm peer dependency conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "typescript": "^5.4.0",
     "vite": "^6.4.2",
     "vite-svg-loader": "^5.1.0",
-    "vitest": "^4.1.0",
+    "vitest": "^3.1.2",
     "vue-eslint-parser": "^10.1.3"
   }
 }


### PR DESCRIPTION
vitest was bumped to v4 while @vitest/browser, @vitest/coverage-v8, and @storybook/experimental-addon-test all require v3. Pinning to ^3.1.2 restores consistency across all vitest ecosystem packages.