### PR TITLE
Fix speaker image cropping in full-width event card

### DIFF
--- a/desparchado/frontend/components/presentational/components/event-card-full-width/styles.scss
+++ b/desparchado/frontend/components/presentational/components/event-card-full-width/styles.scss
@@ -99,6 +99,8 @@
       width: 1.875rem;
       height: 1.875rem;
       border-radius: 100%;
+      object-fit: cover;
+      object-position: center top;
     }
 
     &__speaker-name {


### PR DESCRIPTION
Closes #735 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved speaker avatar rendering in event cards so images crop more cleanly and stay centered near the top.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->